### PR TITLE
Hide grey testimonial stars

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -802,7 +802,7 @@ nav a:hover {
 }
 
 .stars-bg {
-  color: var(--color-muted);
+  visibility: hidden;
 }
 
 .stars-fg {


### PR DESCRIPTION
## Summary
- Hide background testimonial stars to prevent duplicate gray and gold icons.

## Testing
- ⚠️ `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b241bc6394832188b2fc74695ba47d