### PR TITLE
Hide duplicated grey stars in testimonials

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -802,7 +802,7 @@ nav a:hover {
 }
 
 .stars-bg {
-  visibility: hidden;
+  opacity: 0; /* Hide grey background stars */
 }
 
 .stars-fg {


### PR DESCRIPTION
## Summary
- remove visible grey star layer so only gold ratings remain

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2430ad9ec832194d3e9f4751c100f